### PR TITLE
Update to scijava-pom 30.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>29.2.1</version>
+		<version>30.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-modelzoo</artifactId>
-	<version>0.9.9-SNAPSHOT</version>
+	<version>0.9.10-SNAPSHOT</version>
 
 	<name>ImageJ bioimage.io modelzoo library</name>
 	<description>This is the bioimage.io modelzoo library for ImageJ.</description>

--- a/src/test/java/net/imagej/modelzoo/consumer/DefaultModelZooPredictionTest.java
+++ b/src/test/java/net/imagej/modelzoo/consumer/DefaultModelZooPredictionTest.java
@@ -28,6 +28,7 @@
  */
 package net.imagej.modelzoo.consumer;
 
+import net.imagej.Dataset;
 import net.imagej.ImageJ;
 import net.imagej.modelzoo.ModelZooArchive;
 import net.imagej.modelzoo.consumer.model.prediction.DefaultPredictionOutput;
@@ -57,7 +58,9 @@ public class DefaultModelZooPredictionTest {
 
 		Path img = Paths.get(getClass().getResource("denoise2D/input.tif").toURI());
 
-		Img input = (Img) ij.io().open(img.toAbsolutePath().toString());
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// Img input = (Img) ij.io().open(img.toAbsolutePath().toString());
+		Img input = (Img) ij.scifio().datasetIO().open(img.toAbsolutePath().toString());
 
 		File archive1 = new File(getClass().getResource("denoise2D/dummy-0.2.0-csbdeep.bioimage.io.zip").toURI());
 		File archive2 = new File(getClass().getResource("denoise2D/dummy-0.3.0.model.bioimage.io.zip").toURI());

--- a/src/test/java/net/imagej/modelzoo/consumer/DefaultSingleInputPredictionTest.java
+++ b/src/test/java/net/imagej/modelzoo/consumer/DefaultSingleInputPredictionTest.java
@@ -54,7 +54,10 @@ public class DefaultSingleInputPredictionTest {
 
 		// load input image
 		Path img = Paths.get(getClass().getResource("denoise2D/input.tif").toURI());
-		Img input = (Img) ij.io().open(img.toAbsolutePath().toString());
+
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// Img input = (Img) ij.io().open(img.toAbsolutePath().toString());
+		Img input = (Img) ij.scifio().datasetIO().open(img.toAbsolutePath().toString());
 		Img imgFloat = ij.op().convert().float32(input);
 
 		// load pretrained model

--- a/src/test/java/net/imagej/modelzoo/consumer/command/ChangeSampleImageCommandTest.java
+++ b/src/test/java/net/imagej/modelzoo/consumer/command/ChangeSampleImageCommandTest.java
@@ -51,7 +51,9 @@ public class ChangeSampleImageCommandTest {
 
 		Path img = Paths.get(getClass().getResource("../denoise2D/input.tif").toURI());
 
-		Img input = (Img) ij.io().open(img.toAbsolutePath().toString());
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// Img input = ((Img) ij.io().open(img.toAbsolutePath().toString());
+		Img input = (Img) ij.scifio().datasetIO().open(img.toAbsolutePath().toString());
 
 		Path model = Paths.get(getClass().getResource("../denoise2D/dummy.model.bioimage.io.zip").toURI());
 

--- a/src/test/java/net/imagej/modelzoo/consumer/command/DefaultModelZooPredictionCommandTest.java
+++ b/src/test/java/net/imagej/modelzoo/consumer/command/DefaultModelZooPredictionCommandTest.java
@@ -50,7 +50,9 @@ public class DefaultModelZooPredictionCommandTest {
 
 		Path img = Paths.get(getClass().getResource("../denoise2D/input.tif").toURI());
 
-		Img input = (Img) ij.io().open(img.toAbsolutePath().toString());
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// Img input = ((Img) ij.io().open(img.toAbsolutePath().toString());
+		Img input = (Img) ij.scifio().datasetIO().open(img.toAbsolutePath().toString());
 
 		Path model = Paths.get(getClass().getResource("../denoise2D/dummy.model.bioimage.io.zip").toURI());
 

--- a/src/test/java/net/imagej/modelzoo/howto/E01_Prediction.java
+++ b/src/test/java/net/imagej/modelzoo/howto/E01_Prediction.java
@@ -62,7 +62,9 @@ public class E01_Prediction {
 		String modelPath = getClass().getResource("/net/imagej/modelzoo/consumer/denoise2D/dummy.model.bioimage.io.zip").getPath();
 
 		// load image
-		Img input = (Img) ij.io().open(imgPath);
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// Img input = ((Img) ij.io().open(imgPath);
+		Img input = (Img) ij.scifio().datasetIO().open(imgPath);
 
 		ij.ui().show(input);
 
@@ -92,7 +94,9 @@ public class E01_Prediction {
 		String modelPath = getClass().getResource("/net/imagej/modelzoo/consumer/denoise2D/dummy.model.bioimage.io.zip").getPath();
 
 		// load image
-		RandomAccessibleInterval input = (Img) ij.io().open(imgPath);
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// RandomAccessibleInterval input = ((Img) ij.io().open(imgPath);
+		RandomAccessibleInterval input = (Img) ij.scifio().datasetIO().open(imgPath);
 
 		// create prediction
 		DefaultModelZooPrediction prediction = new DefaultModelZooPrediction(ij.context());

--- a/src/test/java/net/imagej/modelzoo/howto/E05_RunSanityCheck.java
+++ b/src/test/java/net/imagej/modelzoo/howto/E05_RunSanityCheck.java
@@ -54,7 +54,9 @@ public class E05_RunSanityCheck {
 		String imgPath = getClass().getResource("/blobs.png").getPath();
 
 		// load image
-		Img input = (Img) ij.io().open(imgPath);
+		// TODO scifio DatasetIOPlugin fixed in future versions (fixed in 0.41.2)
+		// Img input = (Img) ij.io().open(imgPath);
+		Img input = (Img) ij.scifio().datasetIO().open(imgPath);
 
 		// create noisy image from input image
 		Img noisy = ij.op().create().img(input);


### PR DESCRIPTION
Issue https://github.com/imagej/imagej-modelzoo/issues/9 prompted an update to scijava-pom 30.0.0 in order to fix an exception occuring since a recent update of imagelib2-cache.

However, there is a bug in scifio 0.41.1 that prevents org.scijava.io.IOService and io.scif.io.DatasetIOPlugin from loading images. I applied a quick fix by using io.scif.services.DatasetIOService instead... The bug is fixed in scifio 0.41.2-SNAPSHOT, so the code should probably roll back to using IOService at the next scifio update.